### PR TITLE
入力メソッドを変更

### DIFF
--- a/004_Lunutu_20.04/Vagrantfile
+++ b/004_Lunutu_20.04/Vagrantfile
@@ -34,7 +34,7 @@ sudo apt-get update -y
 
 # 日本語環境の設定
 sudo apt-get install -y fonts-ipafont fonts-ipaexfont
-sudo apt-get install -y language-pack-ja-base language-pack-ja fcitx-mozc
+sudo apt-get install -y language-pack-ja-base language-pack-ja ibus fcitx fcitx-mozc 
 sudo apt-get install -y firefox-locale-ja language-pack-gnome-ja
 sudo update-locale LANG=ja_JP.UTF-8 LANGUAGE=”ja_JP:ja” LC_ALL=ja_JP.UTF-8
 sudo localectl set-keymap jp106


### PR DESCRIPTION
やはり日本語入力が有効にならないため、入力メソッドを複数導入するスクリプトに書き換え
ibusとfcitx-mozcの両方が必要だった模様。
インストール後に日本語を入力できるところまで確認済み。